### PR TITLE
Hadoop resources

### DIFF
--- a/resources/reverse_engineering_hadoop.markdown
+++ b/resources/reverse_engineering_hadoop.markdown
@@ -19,6 +19,163 @@ into a cohesive overview of the findings.
 
 ## [Number of map Tasks](./top_level_overview.markdown#Point-1-&-2:-Splitting-and-Assigning-Tasks)
 
+<details>
+  <summary>
+    <b id="number-of-map-tasks">Click to see test output</b>
+  </summary>
+
+```
+********************************************************************************************
+TestCase(num_files=1, file_size_in_MiB=1, description='single file smaller than block size')
+********************************************************************************************
+formatting the namenode
+executing: /usr/local/hadoop/bin/hdfs namenode -format -y
+Formatting using clusterid: CID-b04b700b-3161-427d-9e80-cc2d225701c8
+
+starting hdfs
+executing: /usr/local/hadoop/sbin/start-dfs.sh
+Starting namenodes on [localhost]
+localhost: Warning: Permanently added 'localhost' (ECDSA) to the list of known hosts.
+Starting datanodes
+Starting secondary namenodes [e3538724a1e9]
+e3538724a1e9: Warning: Permanently added 'e3538724a1e9,172.17.0.2' (ECDSA) to the list of known hosts.
+
+starting yarn
+executing: /usr/local/hadoop/sbin/start-yarn.sh
+Starting resourcemanager
+Starting nodemanagers
+
+currently running jvms
+executing: /usr/local/java/bin/jps
+834 ResourceManager
+1315 Jps
+598 SecondaryNameNode
+361 DataNode
+954 NodeManager
+237 NameNode
+
+creating hdfs folder for the hadoop user
+executing: /usr/local/hadoop/bin/hdfs dfs -mkdir /user
+executing: /usr/local/hadoop/bin/hdfs dfs -mkdir /user/hadoop
+/user/hadoop created in hdfs
+
+generating word files
+Input files generated: 1, File Size: 1 MiB
+executing: /usr/local/hadoop/bin/hdfs dfs -put /home/hadoop/input
+
+configuration property values
+executing: /usr/local/hadoop/bin/hadoop org.apache.hadoop.hdfs.tools.GetConf -confKey dfs.block.size
+property: dfs.block.size, value: 16777216
+
+run mapreduce wordcount
+2019-07-03 21:27:37,886 WARN util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
+2019-07-03 21:27:38,608 INFO client.RMProxy: Connecting to ResourceManager at /0.0.0.0:8032
+2019-07-03 21:27:39,235 INFO mapreduce.JobResourceUploader: Disabling Erasure Coding for path: /tmp/hadoop-yarn/staging/hadoop/.staging/job_1562189247326_0001
+2019-07-03 21:27:39,509 INFO input.FileInputFormat: Total input files to process : 1
+2019-07-03 21:27:40,409 INFO mapreduce.JobSubmitter: number of splits:1
+2019-07-03 21:27:40,470 INFO Configuration.deprecation: yarn.resourcemanager.system-metrics-publisher.enabled is deprecated. Instead, use yarn.system-metrics-publisher.enabled
+2019-07-03 21:27:40,984 INFO mapreduce.JobSubmitter: Submitting tokens for job: job_1562189247326_0001
+2019-07-03 21:27:40,986 INFO mapreduce.JobSubmitter: Executing with tokens: []
+2019-07-03 21:27:41,200 INFO conf.Configuration: resource-types.xml not found
+2019-07-03 21:27:41,200 INFO resource.ResourceUtils: Unable to find 'resource-types.xml'.
+2019-07-03 21:27:41,579 INFO impl.YarnClientImpl: Submitted application application_1562189247326_0001
+2019-07-03 21:27:41,632 INFO mapreduce.Job: The url to track the job: http://e3538724a1e9:8088/proxy/application_1562189247326_0001/
+2019-07-03 21:27:41,633 INFO mapreduce.Job: Running job: job_1562189247326_0001
+2019-07-03 21:27:49,779 INFO mapreduce.Job: Job job_1562189247326_0001 running in uber mode : false
+2019-07-03 21:27:49,781 INFO mapreduce.Job:  map 0% reduce 0%
+2019-07-03 21:27:54,817 INFO mapreduce.Job:  map 100% reduce 0%
+2019-07-03 21:27:59,861 INFO mapreduce.Job:  map 100% reduce 100%
+2019-07-03 21:28:01,883 INFO mapreduce.Job: Job job_1562189247326_0001 completed successfully
+2019-07-03 21:28:01,996 INFO mapreduce.Job: Counters: 54
+        File System Counters
+                FILE: Number of bytes read=1058486
+                FILE: Number of bytes written=2564427
+                FILE: Number of read operations=0
+                FILE: Number of large read operations=0
+                FILE: Number of write operations=0
+                HDFS: Number of bytes read=1048117
+                HDFS: Number of bytes written=1005
+                HDFS: Number of read operations=8
+                HDFS: Number of large read operations=0
+                HDFS: Number of write operations=2
+                HDFS: Number of bytes read erasure-coded=0
+        Job Counters
+                Launched map tasks=1
+                Launched reduce tasks=1
+                Data-local map tasks=1
+                Total time spent by all maps in occupied slots (ms)=21104
+                Total time spent by all reduces in occupied slots (ms)=22960
+                Total time spent by all map tasks (ms)=2638
+                Total time spent by all reduce tasks (ms)=2870
+                Total vcore-milliseconds taken by all map tasks=2638
+                Total vcore-milliseconds taken by all reduce tasks=2870
+                Total megabyte-milliseconds taken by all map tasks=2701312
+                Total megabyte-milliseconds taken by all reduce tasks=2938880
+        Map-Reduce Framework
+                Map input records=1048
+                Map output records=1048
+                Map output bytes=1054288
+                Map output materialized bytes=1058486
+                Input split bytes=117
+                Combine input records=0
+                Combine output records=0
+                Reduce input groups=1
+                Reduce shuffle bytes=1058486
+                Reduce input records=1048
+                Reduce output records=1
+                Spilled Records=2096
+                Shuffled Maps =1
+                Failed Shuffles=0
+                Merged Map outputs=1
+                GC time elapsed (ms)=83
+                CPU time spent (ms)=1230
+                Physical memory (bytes) snapshot=468463616
+                Virtual memory (bytes) snapshot=5266083840
+                Total committed heap usage (bytes)=364904448
+                Peak Map Physical memory (bytes)=286240768
+                Peak Map Virtual memory (bytes)=2630541312
+                Peak Reduce Physical memory (bytes)=182222848
+                Peak Reduce Virtual memory (bytes)=2635542528
+        Shuffle Errors
+                BAD_ID=0
+                CONNECTION=0
+                IO_ERROR=0
+                WRONG_LENGTH=0
+                WRONG_MAP=0
+                WRONG_REDUCE=0
+        File Input Format Counters
+                Bytes Read=1048000
+        File Output Format Counters
+                Bytes Written=1005
+
+stopping hdfs
+executing: /usr/local/hadoop/sbin/stop-dfs.sh
+Stopping namenodes on [localhost]
+localhost: WARNING: namenode did not stop gracefully after 5 seconds: Trying to kill with kill -9
+localhost: ERROR: Unable to kill 237
+Stopping datanodes
+localhost: WARNING: datanode did not stop gracefully after 5 seconds: Trying to kill with kill -9
+localhost: ERROR: Unable to kill 361
+Stopping secondary namenodes [e3538724a1e9]
+e3538724a1e9: WARNING: secondarynamenode did not stop gracefully after 5 seconds: Trying to kill with kill -9
+e3538724a1e9: ERROR: Unable to kill 598
+
+stopping yarn
+executing: /usr/local/hadoop/sbin/stop-yarn.sh
+Stopping nodemanagers
+localhost: WARNING: nodemanager did not stop gracefully after 5 seconds: Trying to kill with kill -9
+localhost: ERROR: Unable to kill 954
+Stopping resourcemanager
+
+check that no jvms running hadoop daemons are present
+executing: /usr/local/java/bin/jps
+2938 Jps
+
+cleaning up /tmp/hadoop-*
+wrench-computer:hadoop_mr_tests ryan$
+```
+</details>
+
 When a Hadoop job starts up, the input data is divided into
 *N* splits, where *N* is equal to the `ceiling(file_size/HDFS_block_size)`.
 The `HDFS_block_size` is a configurable property in the `hdfs-default.xml` file
@@ -77,6 +234,29 @@ Where `N` is the number of files, `s_i` is the size of the `ith` file, and `b`
 is the block size.
 
 ## [Map Output Materialized Bytes](./top_level_overview.markdown#Point-3-&-4:-Mapping-&-Handling-Intermediate-map-Values)
+
+<details>
+  <summary>
+    <b id="map-output-materialized-bytes">Click to see test output</b>
+  </summary>
+
+```
+-9223372036854775808:  10000000 01111111 11111111 11111111 11111111 11111111 11111111 11111111 11111111 len: 9  expected len: 9
+         -2147483648:                                      10000100 01111111 11111111 11111111 11111111 len: 5  expected len: 5
+            -8388608:                                               10000101 01111111 11111111 11111111 len: 4  expected len: 4
+              -32768:                                                        10000110 01111111 11111111 len: 3  expected len: 3
+                -128:                                                                 10000111 01111111 len: 2  expected len: 2
+                -112:                                                                          10010000 len: 1  expected len: 1
+                  -1:                                                                          11111111 len: 1  expected len: 1
+                   1:                                                                          00000001 len: 1  expected len: 1
+                 128:                                                                 10001111 10000000 len: 2  expected len: 2
+               32768:                                                        10001110 10000000 00000000 len: 3  expected len: 3
+             8388608:                                               10001101 10000000 00000000 00000000 len: 4  expected len: 4
+          2147483648:                                      10001100 10000000 00000000 00000000 00000000 len: 5  expected len: 5
+ 9223372036854775808:  10001000 10000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 len: 9  expected len: 9
+ ```
+</details>
+
 This test was built to check the following:
 
 > Test to determine the number of spill files and map output materialized bytes
@@ -95,6 +275,34 @@ it is possible to estimate the materialized output given the supplied parameters
 as shown in the above function signature.
 
 ## Map Merge Parts
+
+<details>
+  <summary>
+    <b id="map-merge-parts">Click to see test output</b>
+  </summary>
+
+```
+2019-07-12 01:14:32,075 INFO [SpillThread] org.apache.hadoop.mapred.MapTask: Finished spill 0, file path: attempt_1562894051760_0001_m_000000_0_spill_0.out
+
+2019-07-12 01:14:32,171 INFO [SpillThread] org.apache.hadoop.mapred.MapTask: Finished spill 1, file path: attempt_1562894051760_0001_m_000000_0_spill_1.out
+
+2019-07-12 01:14:32,254 INFO [main] org.apache.hadoop.mapred.MapTask: Finished spill 2, file path: attempt_1562894051760_0001_m_000000_0_spill_2.out
+
+2019-07-12 01:14:32,261 INFO [main] org.apache.hadoop.mapred.Merger: Merging 3 sorted segments
+
+2019-07-12 01:14:32,263 INFO [main] org.apache.hadoop.mapred.Merger: Down to the last merge-pass, with 3 segments left of total size: 524294 bytes
+
+2019-07-12 01:14:36,409 INFO [main] org.apache.hadoop.mapreduce.task.reduce.MergeManagerImpl: MergerManager: memoryLimit=535088320, maxSingleShuffleLimit=133772080, mergeThreshold=353158304, ioSortFactor=3, memToMemMergeOutputsThreshold=3
+
+2019-07-12 01:14:36,598 INFO [main] org.apache.hadoop.mapred.Merger: Merging 1 sorted segments
+
+2019-07-12 01:14:36,598 INFO [main] org.apache.hadoop.mapred.Merger: Down to the last merge-pass, with 1 segments left of total size: 524286 bytes
+
+2019-07-12 01:14:36,646 INFO [main] org.apache.hadoop.mapred.Merger: Merging 1 sorted segments
+
+2019-07-12 01:14:36,647 INFO [main] org.apache.hadoop.mapred.Merger: Down to the last merge-pass, with 1 segments left of total size: 524286 bytes
+```
+</details>
 
 Each map task [merges its spill files](./top_level_overview.markdown#Point-3-&-4:-Mapping-&-Handling-Intermediate-map-Values)
 back into a single partitioned map output file. The tests here show that both

--- a/resources/reverse_engineering_hadoop.markdown
+++ b/resources/reverse_engineering_hadoop.markdown
@@ -1,0 +1,119 @@
+# Reverse Engineering Hadoop
+
+Thanks to the work done by Ryan Tanaka, we have been able to extrapolate many
+subtle details that go into running a Hadoop job.  In this section, all data is
+sourced from the original results that can be found in the comments in the
+[source code](https://github.com/wrench-project/understanding_hadoop/tree/master/hadoop_mr_tests),
+as well as in the original README.
+
+The following four tests were ran, and will be summarized:
+
+1. [Number of map Tasks](#number-of-map-tasks)
+2. [Map Output Materialized Bytes](#map-output-materialized-bytes)
+3. [Map Merge Parts](#map-merge-parts)
+4. [Reduce Merge Parts](#reduce-merged-parts)
+
+What this section will attempt to do is consolidate the valuable information
+obtained from running these tests, and integrate the results from code comments 
+into a cohesive overview of the findings.
+
+## [Number of map Tasks](./top_level_overview.markdown#Point-1-&-2:-Splitting-and-Assigning-Tasks)
+
+When a Hadoop job starts up, the input data is divided into
+*N* splits, where *N* is equal to the `ceiling(file_size/HDFS_block_size)`.
+The `HDFS_block_size` is a configurable property in the `hdfs-default.xml` file
+(note that this is not the actual name of the property).
+For this test, the block size was fixed at `16 MiB`.  The idea behind
+this test was to process a number of inputs with varying input sizesÂ
+to determine how many map tasks are created as a function of the input.
+
+The results from running four separate test cases are as follows:
+
+```python3
+TestCase = namedtuple("TestCase", ["num_files", "file_size_in_MiB", "description"])
+
+test_cases = [
+    TestCase(1, 1, "single file smaller than block size"),          # Launched map tasks=1
+    TestCase(1, 20, "single file larger than block size"),          # Launched map tasks=2
+    TestCase(2, 1, "two small files that fit into a single block"), # Launched map tasks=2
+    TestCase(2, 20, "two files each larger than a block")           # Launched map tasks=4
+]
+```
+
+So we can represent this as the following simple block of pseudocode:
+
+```
+# Read input files
+for file in input_files:
+  if file.size() < block_size:
+    map_task.launch(file)
+  else:
+    while file.size() > block_size:
+      split = file.split(block_size) # split off a `block_size` sized chunk
+      map_task.launch(split)
+    map_task.launch(file)
+```
+While this isn't a true representation of how map tasks are delegated, it helps
+us to see the relationship between file, file size, and number of map tasks.
+
+Let's verify this checks out.
+* When `input_files == 1 and file.size() < block_size`
+we enter our first check a single time, and a single `map_task` is launched.
+* The second case, `input_files == 1 and file.size() > block_size`, so we enter
+the `else` block and split the file, a single map task is launched.  Our next
+check on the `while` loop returns `False`, so we exit and launch one more map
+task.  Thus, a total of two map tasks are launched.
+* In the third test we iterate over two files, each entering the first `if`
+block, resulting in two map tasks.
+* For our final test case, we see the same result as in our second test case
+repeated twice. So, we end up with four map tasks.
+
+We can therefore represent the number of map tasks as a function of number of
+files and file size:
+
+`number_of_map_tasks = sum(ceil(s_i / b))`
+
+Where `N` is the number of files, `s_i` is the size of the `ith` file, and `b`
+is the block size.
+
+## [Map Output Materialized Bytes](./top_level_overview.markdown#Point-3-&-4:-Mapping-&-Handling-Intermediate-map-Values)
+This test was built to check the following:
+
+> Test to determine the number of spill files and map output materialized bytes
+based on map inputs, map output buffer size, and map sort spill percent assuming
+a single mapper, 1 or more reducers, and that no combiners are run.
+
+The key take away from this test is how zero compression, along with the
+partition size, affects the materialized bytes.  By using the following function:
+
+```python3
+def estimate_map_output_materialized_bytes(num_words, num_reducers, key_num_bytes, value_num_bytes)
+```
+
+which utilizes Hadoop's own logic for implementing a zero compression algorithm,
+it is possible to estimate the materialized output given the supplied parameters
+as shown in the above function signature.
+
+## Map Merge Parts
+
+Each map task [merges its spill files](./top_level_overview.markdown#Point-3-&-4:-Mapping-&-Handling-Intermediate-map-Values)
+back into a single partitioned map output file. The tests here show that both
+the map side merge, and the reduce side merge follow the same general approach.
+I.e., that files are queued into memory, and consumed on each merge round,
+minimizing the total number of merges required to achieve a `merge factor` 
+number of files to be merged on the final round.  A sample of the behavior is
+shown below:
+
+```
+simulate_merges_using_variable_pass_factor(5, 23)
+pass: 1, current_num_segments: 23, pass_factor: 3, remaining_num_segments: 21
+pass: 2, current_num_segments: 21, pass_factor: 5, remaining_num_segments: 17
+pass: 3, current_num_segments: 17, pass_factor: 5, remaining_num_segments: 13
+pass: 4, current_num_segments: 13, pass_factor: 5, remaining_num_segments: 9
+pass: 5, current_num_segments: 9, pass_factor: 5, remaining_num_segments: 5
+pass: 6, current_num_segments: 5, pass_factor: 5, remaining_num_segments: 1
+```
+
+## Reduce Merge Parts
+
+// TODO

--- a/resources/top_level_overview.markdown
+++ b/resources/top_level_overview.markdown
@@ -1,0 +1,283 @@
+# MapReduce
+
+This page serves as an overview of what constitutes a MapReduce job.  We then
+look into what's going on under the hood relating to the Hadoop implementation
+of MapReduce.  The lower-level, implementation details realting to
+[How Hadoop Handles MapReduce](#how-hadoop-handles-mapreduce) will be covered
+in the __Roadmap__ section.
+
+### What is MapReduce?
+As per _Map Reduce: Simplified Data Processing on Large Clusters_:
+
+MapReduce is a programming model inspired by the synonymous primitives present
+in Lisp and many other functional programming languages.
+
+Conceptually, MapReduce can be broken into the following:
+
+1. __Computation__: Accepts a set of _input_ `(key, value)` pairs and produces a
+set of _output_ `(key, value)` pairs.
+
+2. __Map__: A user defined function that takes input pairs and produces a set of _intermediate_ `(key, value)` pairs. The MapReduce library groups all of these
+intermediate values associated with the same intermediate key, _I_, and passes
+them to the reduce function.
+
+3. __Reduce__:  Is a user defined function that accepts an intermediate key,
+`I`, and a set of values for that key. It merges the values together.  Typically
+zero or one output values are produced by any _Reduced_ invocation.
+(The list of values are passed by an iterator to deal with memory availability.)
+
+The above computational process has the following type associations:
+
+```
+map:    (k1, v1)       -> list(k2, v2)
+
+reduce: (k2, list(v2)) -> list(v2)
+```
+
+That is, a map task, which is a copy of a user-defined function, accepts
+key-value pairs, `(k1, v1)`, and outputs `(k2, v2)`, representative of the
+intermediate value pairs, `I`.  These intermediate pairs are not necessarily of
+the same type as the input pairs.  The reducer then accepts all keys, `k2`, and
+the corresponding list of values, `list(v2)`.  The reducer then performs some
+user-defined operation on the list, and produces some output.
+
+
+#### Steps in a MapReduce Process:
+
+The following is a simplification of the steps outlined in
+_Map Reduce: Simplified Data Processing on Large Clusters_.  After we break down
+the process, we'll explore how Hadoop handles each of the following:
+
+1. The MapReduce library splits the input into _M_ chunks, and starts up copies
+of the program on multiple machines.
+
+2. The _master_ fork assigns tasks to the _worker_ nodes who are just running
+copies of the _user program_.  There are `M` map tasks, and `R` reduce tasks
+that the _master_ must assign. Note that a worker node takes on the role of
+either map, or reduce. Typically, there are many more map nodes than reduce
+nodes.
+
+3. A _worker_ assigned a map task, reads in the contents of the corresponding
+input split.  The _worker_ parses (key, values) pairs and passes it to the map
+function. The _intermediate_ (key, value) pairs produced by the mapping are
+buffered into memory.
+
+4. The local disk it partitioned into `R` regions by the _partitioning
+function_. The buffered _intermediate_ pairs produced by a map worker are
+periodically written to these partitions, with the particular location of these
+writes sent back to `master` for use by the reduce workers.
+
+5. When the `master` notifies a _reduce_ worker about a particular location of
+_intermediate_ key-value pairs, it reads the buffered data from the local
+disks of the map workers. When a reduce worker has read all intermediate data,
+it sorts it by key so that all of the same keys are grouped together. The
+sorting is needed because many different keys can map to the same reduce task.
+If the amount of intermediate data is too large to fit in memory, an external
+sort is used.
+
+6. The reduce worker iterates over the sorted data and for each unique
+intermediate key encountered, it passes the key and the corresponding set of
+intermediate values to the user’s _reduce_ function. The output of the reduce
+function is appended to a final output file for this reduce partition.
+
+7. When all map tasks and reduce tasks have been completed, the call to
+MapReduce reaches a return statement back to user code.
+
+## How Hadoop Handles MapReduce
+Now that we are comfortable with what MapReduce is, let's look into
+understanding how Hadoop handles MapReduce.  Here, each point expands on the
+corresponding number in [Steps in a MapReduce Process](#steps-in-a-map-reduce-process).
+
+Before a job can be started, however, it must run through a few steps:
+1. A job must be submitted via the user API.
+2. The resource manager retrieves the job ID (application ID)
+3. The job client checks output specification, computes splits (which can also
+  be changed to be computed over the cluster, useful for a job with many splits),
+  and then copy job resources over to the HDFS.
+
+#### Point 1 & 2: Splitting and Assigning Tasks
+HDFS (Hadoop Distributed File System) breaks down large files into configurable
+sized blocks, defaulting to 64 MB.  It then stores copies of these blocks across
+nodes in the cluster.  
+
+Using YARN (YARN Applied Resource Negotiator), The resource manager acts as the
+cluster resource manager (no way), as well as the job scheduling facility.  The
+resource manager creates an Application Master daemon (AMD) to monitor the
+life cycle of the job.  One of the initial things that the AMD does is distinguish
+which HDFS blocks are needed for processing.  The AMD requests data from the
+`NameNode` on where the relevant replicated blocks of data are stored. With this
+information, the AMD then requests the resource manager to have map tasks
+process the specified blocks on the same nodes where the data is stored. This
+data locality helps to avoid potentially painful network bottlenecks.
+
+The number of map tasks correspond to the number of created blocks, while the
+number of reducers are configurable via the `mapreduce.jobs.reduces` property.
+Thus for each input split, a map task is spawned.  The number of maps is
+typically driven by the number of HDFS blocks in the input file. This block size
+is configurable, and therefore allows for a workaround when wishing to adjust the
+number of map tasks.
+
+There does exists a `mapred.map.tasks` parameter, however this is simply a hint
+to the `InputFormat` (which describes the input-specification for a Map-Reduce
+job), regarding the number of map tasks.
+
+Thus, e.g., if you expect 10TiB of input data and have 128MiB DFS blocks, you'll
+end up with 81920 maps, unless your `mapred.map.tasks` is even larger.
+Ultimately the `InputFormat` determines the number of maps.
+
+```
+Number of blocks = integer ceiling of input data over block size
+
+= ceil( input_data / block_size )
+= (10 * 2^40) / (2^7 * 2^20)
+= (10 * 2^40) / 2^27
+= 10 * 2^13
+= 10 * 8192
+= 81920
+```
+
+The question remains: What happens when a data record gets split into two
+different blocks?  After all, Hadoop has no idea about what the input data is
+going to look like, so it certainly can't distinguish where one record ends and
+the other begins.
+
+To deal with this, Hadoop uses something called _input splits_.  This is a
+logical representation of that data.  When a job client first calculates the
+input splits, it determines where the first complete record in a block begins,
+and where the last record ends.  In cases where the last record within a block
+has been split off, the input split includes location data on the remnants of
+the record, including the byte offset of the partial record.
+
+
+#### Point 3 & 4: Mapping & Handling Intermediate map Values
+
+For each map task, Hadoop places intermediate values into a circular buffer,
+located in memory, and is configurable under `mapreduce.task.io.sort.mb`
+(defaults to 100MB). This value is the total amount of data that a particular
+map task can output. If a configurable percentage of this limit is met, then the
+data will be spilled to the disk as a _shuffle spill file_.  Spills are written
+in a round-robin fashion.
+
+On any given node, multiple map tasks can be run, and as a result many spill
+files can be created.  Hadoop merges all of the spill files, sorts, and then
+partitions the resulting file based upon the number of reducers.  However, before
+an individual spill file is even written to disk, the spill thread does a few
+things:
+
+1. The spill file itself is partitioned based upon the number of reducers.
+2. Within each of the partitions of a spill file, the thread runs an in-memory
+sort by key.
+3. Finally, if a combiner function exists, it is run on the output of the
+resulting sort. The combiner allows for a more compact map output, leaving less
+data to write locally, thus less data to transfer to the reducer.  It is
+important to note that a combiner basically compresses the data, meaning it
+will eventually have to be decompressed before reducing.
+
+The circular buffer has a configurable threshold, defaulted to 80%. The buffer
+below has `0.8 * 100 MB = 80 MB` of data written, which is the limit in this
+example:
+
+```
+[XXXXXXXX--]
+```
+
+The data is spilled in a separate thread to allow continuation of the map task:
+
+```
+The block in || is being written to disk, x = 10 MB written to memory by mapper
+[|XXXXXXXXX|x-]
+
+Another x = 10 MB written to memory
+[|XXXXXXXXX|xx]
+
+Spill thread completes, clear 80 MB block. 10 MB written to memory by mapper.
+[x-------xx]
+```
+
+Before the write to disk actually occurs, two things happen:
+* The output is split into `R` partitions, again based on the number of
+reduce tasks.
+* The `(key, value)` pairs are sorted, in-memory, using a QuickSort algorithm
+based on (partitionID, key).
+
+In the above case, the rate at which the mapper was writing data to memory was
+less than the rate that it took to spill the block to disk.  However,
+it can be the case where the mapper is writing data faster than the
+spill thread is able to free memory.  In such a scenario, the mapper would be
+blocked until the spill thread has had a chance to clear the buffer.
+
+It's important to note that Hadoop uses zero compressed Long and Int values for
+map output.  Here is a quote from _Hadoop Definitive Guide_, (table 8-2, page 261)
+relating to the tests ran in the _Reverse Engineering Hadoop_ section:
+
+>"Map output materialized bytes" - The number of bytes of map output actually
+written to disk. If map output compression is enabled, this is reflected in the
+counter value.
+
+>"Map output bytes" - The number of bytes of uncompressed output produced by all
+the maps in the job. Incremented every time the collect() method is called on
+the map's OutputCollector.
+
+#### Point 5: Preparing for a reduce task
+MapReduce has the guarantee that the input to every reducer is sorted by key. As
+mentioned in _point 3 & 4_, the system sorts and merges the disjoint spill files
+of individual map tasks and then transfers the map outputs to the reducers.  The
+process where map outputs are fetched by reduce tasks in known as the _shuffle_.
+In other contexts, the shuffle can be taken as the entire process from maps
+producing output, to reducers consuming input.  For our purposes, it helps to
+distinguish the shuffle phase as a discrete step.
+
+An __Event Fetcher__ fetches map task completion events over a network, and then
+adds them to the fetch queue to be consumed by the fetchers themselves.  These
+fetchers are run in separate threads, configurable in
+`mapred.reduce.parallel.copies`, which defaults to five.  The fetchers store the
+map outputs in memory with its own configurable memory buffer.
+
+With Memory-To-Memory enabled, when the amount of map tasks reaches a
+configurable threshold, in-memory merge is initiated.  The outputs of the
+`MemoryToMemory` merge are stored in memory, when the memory buffer storing
+these outputs reaches a certain percentage, the `InMemory` merger is invoked.
+The `OnDisk` merger is triggered each time the number of files increases  by
+`2 * mapreduce.task.io.sorter - 1`, but it does not merger more than
+`mapreduce.task.io.sort.factor` files.
+
+```
+[map_output_1]_________[mem_to_mem]____[mem_to_mem_output]_
+[map_output_2]________/                                    \
+                                                            \
+[map_output_3]_________[mem_to_mem]____[mem_to_mem_output]___\
+[map_output_4]________/                                       \__[InMemory_merger]
+                                                                                  \
+[map_output_5]___________________________________________________[InMemory_merger]_\____OnDisk_merger_
+                                                                                                      \
+[map_output_N-1]________________________________________________________________________OnDisk_merger__\__
+[map_output_N]________________________________________________________________________/
+```
+
+After the `OnDisk` merge, there is a final merge that produces the reducer input files.
+
+The goal of this, "merging in rounds," technique is to merge the minimum number of files
+as a means to get the _merge factor_ for the final round.
+_Figure 6-7_ on page 212 in _Hadoop: The Definitive Guide_ nicely exemplifies
+efficiently merging 40 file segments.
+
+```
+                            Round 5
+4 files --Round 1---> Merge ---> M \
+10 files -Round 2---> Merge ---> E  \
+10 files -Round 3---> Merge ---> R   --Reduce-->
+10 files -Round 4---> Merge ---> G  /
+6 files -----------------------> E /
+```
+
+Here we can see the merge factor as `10` so the algorithm is to merge 4 files,
+producing a single merged file. And three rounds of 10 files, to produce three
+merged files.  Leaving six unmerged, and four merged files for the final round:
+
+`1 + 3 + 6 = 10 = merge factor`.
+
+Resources:
+* Hadoop Definitive Guide, 3rd edition; Tom White
+* [Hadoop MapReduce Comprehensive Description](https://0x0fff.com/hadoop-mapreduce-comprehensive-description/)
+* [Map Reduce: Simplified Data Processing on Large Clusters](https://www.usenix.org/legacy/events/osdi04/tech/full_papers/dean/dean.pdf)
+* https://cwiki.apache.org/confluence/display/HADOOP2/HowManyMapsAndReduces


### PR DESCRIPTION
The rendered markdown pages can be found here:
* [MapReduce Overview](https://github.com/whoodes/understanding_hadoop/blob/hadoop-resources/resources/top_level_overview.markdown)
* [Reverse Engineering](https://github.com/whoodes/understanding_hadoop/blob/hadoop-resources/resources/reverse_engineering_hadoop.markdown)

The reverse engineering portion is still incomplete. I think for the in-depth writings, we can elaborate on the five main piece of MapReduce:

1. Map
2. Sort
3. Shuffle
4. Merge
5. Reduce

Interested in hearing if we should do a separate page for each of the steps.